### PR TITLE
Apply a natural box layout model to all elements

### DIFF
--- a/skeleton/_settings.scss
+++ b/skeleton/_settings.scss
@@ -15,9 +15,9 @@ $COLUMN_NAMES: (
   ten: 10,
   eleven: 11,
   twelve: 12,
-  one-third: 4,
-  two-thirds: 8,
-  one-half: 6
+  one-third: $TOTAL_COLUMNS/3,
+  two-thirds: ($TOTAL_COLUMNS/3)*2,
+  one-half: $TOTAL_COLUMNS/2
   ) !default;
 
 

--- a/skeleton/components/_base.scss
+++ b/skeleton/components/_base.scss
@@ -7,7 +7,11 @@
 html is set to 62.5% so that all the REM measurements throughout Skeleton
 are based on 10px sizing. So basically 1.5rem = 15px :) */
 html {
+  box-sizing: border-box;
   font-size: 62.5%;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
 }
 body {
   font-family: $font-stack;

--- a/skeleton/components/_buttons.scss
+++ b/skeleton/components/_buttons.scss
@@ -14,7 +14,6 @@ input[type='button'] {
 
   display: inline-block;
 
-  box-sizing: border-box;
   height: 38px;
   padding: 0 30px;
 

--- a/skeleton/components/_forms.scss
+++ b/skeleton/components/_forms.scss
@@ -12,10 +12,8 @@ input[type='url'],
 input[type='password'],
 textarea,
 select {
-  box-sizing: border-box;
   height: 38px;
   padding: 6px 10px; /* The 6px vertically centers text on FF, ignored by Webkit */
-
   border: 1px solid $input-border-color;
   border-radius: $global-radius;
   background-color: $input-background-color;

--- a/skeleton/components/_grid.scss
+++ b/skeleton/components/_grid.scss
@@ -7,8 +7,6 @@
 
 .container {
   position: relative;
-
-  box-sizing: border-box;
   width: 100%;
   max-width: $container-width;
   margin: 0 auto;
@@ -24,8 +22,6 @@
 .column,
 .columns {
   float: left;
-
-  box-sizing: border-box;
   width: 100%;
   @include respond-to('bp-small') {
     margin-left: 4%;

--- a/skeleton/components/_utilities.scss
+++ b/skeleton/components/_utilities.scss
@@ -2,11 +2,9 @@
 // ––––––––––––––––––––––––––––––––––––––––––––––––––
 
 .u-full-width {
-  box-sizing: border-box;
   width: 100%;
 }
 .u-max-full-width {
-  box-sizing: border-box;
   max-width: 100%;
 }
 .u-pull-right {


### PR DESCRIPTION
Found the comment very pertinent in [your pull request](https://github.com/dhg/Skeleton/pull/252) decided that made sense to apply it to your scss fork. Also added the calculation of thirds etc, in case I want to change the $TOTAL_COLUMNS.
